### PR TITLE
Upgrade to rescript 11-beta.2

### DIFF
--- a/__tests__/S_Tuple_factory_test.res
+++ b/__tests__/S_Tuple_factory_test.res
@@ -1,13 +1,13 @@
 open Ava
 
 test("Works", t => {
-  let tuple3: (. S.t<'v1>, S.t<'v2>, S.t<'v3>) => S.t<('v1, 'v2, 'v3)> = (. v1, v2, v3) =>
+  let tuple3: (S.t<'v1>, S.t<'v2>, S.t<'v3>) => S.t<('v1, 'v2, 'v3)> = (v1, v2, v3) =>
     S.Tuple.factory([v1->S.toUnknown, v2->S.toUnknown, v3->S.toUnknown])->Obj.magic
 
   let value = ("a", 1, true)
   let any = %raw(`['a', 1, true]`)
 
-  let struct = tuple3(. S.string, S.int, S.bool)
+  let struct = tuple3(S.string, S.int, S.bool)
 
   t->Assert.deepEqual(any->S.parseAnyWith(struct), Ok(value), ())
 })

--- a/__tests__/S_inline_test.res
+++ b/__tests__/S_inline_test.res
@@ -8,7 +8,7 @@ module Stdlib = {
     let omit = (dict: Js.Dict.t<'a>, fields: array<string>): Js.Dict.t<'a> => {
       let dict = dict->copy
       fields->Js.Array2.forEach(field => {
-        Js.Dict.unsafeDeleteKey(. dict, field)
+        Js.Dict.unsafeDeleteKey(dict, field)
       })
       dict
     }
@@ -407,20 +407,20 @@ test("Supports Dict", t => {
 })
 
 test("Supports empty Tuple", t => {
-  let struct = S.tuple0(.)
+  let struct = S.tuple0()
   t->Assert.deepEqual(struct->S.inline, `S.tuple0(.)`, ())
 })
 
 test("Supports Tuple", t => {
-  let struct = S.tuple3(. S.string, S.int, S.bool)
-  let structInlineResult = S.tuple3(. S.string, S.int, S.bool)
+  let struct = S.tuple3(S.string, S.int, S.bool)
+  let structInlineResult = S.tuple3(S.string, S.int, S.bool)
 
   t->assertEqualStructs(struct, structInlineResult, ())
   t->Assert.deepEqual(struct->S.inline, `S.tuple3(. S.string, S.int, S.bool)`, ())
 })
 
 test("Supports Tuple with 10 items", t => {
-  let struct = S.tuple10(.
+  let struct = S.tuple10(
     S.string,
     S.int,
     S.bool,
@@ -432,7 +432,7 @@ test("Supports Tuple with 10 items", t => {
     S.bool,
     S.string,
   )
-  let structInlineResult = S.tuple10(.
+  let structInlineResult = S.tuple10(
     S.string,
     S.int,
     S.bool,
@@ -486,7 +486,7 @@ test("Supports Union", t => {
     S.literalVariant(String("no"), #no),
   ])
 
-  structInlineResult->(Obj.magic: S.t<[#yes | #no]> => unit)
+  let _: S.t<[#yes | #no]> = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -519,21 +519,19 @@ test("Uses S.literalVariant for all literals inside of union", t => {
     S.literalVariant(NaN, #NaN),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #yes
-        | #True
-        | #False
-        | #123
-        | #1232
-        | #"123.456"
-        | #EmptyNull
-        | #EmptyOption
-        | #NaN
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #yes
+      | #True
+      | #False
+      | #123
+      | #1232
+      | #"123.456"
+      | #EmptyNull
+      | #EmptyOption
+      | #NaN
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -572,14 +570,12 @@ test("Adds index for the same structs inside of the union", t => {
     S.string->S.variant(v => #String2(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #String(string)
-        | #String2(string)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #String(string)
+      | #String2(string)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -623,7 +619,7 @@ test("Supports empty Object (ignores transformations)", t => {
   let struct = S.object(_ => 123)
   let structInlineResult = S.object(_ => ())
 
-  t->assertEqualStructs(struct, structInlineResult->(Obj.magic: S.t<unit> => S.t<int>), ())
+  t->assertEqualStructs(struct, (structInlineResult: S.t<unit>)->Obj.magic, ())
   t->Assert.deepEqual(struct->S.inline, `S.object(_ => ())`, ())
 })
 
@@ -634,7 +630,7 @@ test("Supports empty Object in union", t => {
     S.object(_ => ())->S.variant(v => #EmptyObject2(v)),
   ])
 
-  structInlineResult->(Obj.magic: S.t<[#EmptyObject(unit) | #EmptyObject2(unit)]> => unit)
+  let _: S.t<[#EmptyObject(unit) | #EmptyObject2(unit)]> = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -644,13 +640,13 @@ test("Supports empty Object in union", t => {
 })
 
 test("Supports empty Tuple in union", t => {
-  let struct = S.union([S.tuple0(.), S.tuple0(.)])
+  let struct = S.union([S.tuple0(), S.tuple0()])
   let structInlineResult = S.union([
-    S.tuple0(.)->S.variant(v => #EmptyTuple(v)),
-    S.tuple0(.)->S.variant(v => #EmptyTuple2(v)),
+    S.tuple0()->S.variant(v => #EmptyTuple(v)),
+    S.tuple0()->S.variant(v => #EmptyTuple2(v)),
   ])
 
-  structInlineResult->(Obj.magic: S.t<[#EmptyTuple(unit) | #EmptyTuple2(unit)]> => unit)
+  let _: S.t<[#EmptyTuple(unit) | #EmptyTuple2(unit)]> = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -666,14 +662,12 @@ test("Supports Option structs in union", t => {
     S.option(S.float)->S.variant(v => #OptionOfFloat(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #OptionOf123(option<string>)
-        | #OptionOfFloat(option<float>)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #OptionOf123(option<string>)
+      | #OptionOfFloat(option<float>)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -689,14 +683,12 @@ test("Supports Null structs in union", t => {
     S.null(S.float)->S.variant(v => #NullOfFloat(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #NullOf123(option<string>)
-        | #NullOfFloat(option<float>)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #NullOf123(option<string>)
+      | #NullOfFloat(option<float>)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -712,14 +704,12 @@ test("Supports Array structs in union", t => {
     S.array(S.float)->S.variant(v => #ArrayOfFloat(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #ArrayOf123(array<string>)
-        | #ArrayOfFloat(array<float>)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #ArrayOf123(array<string>)
+      | #ArrayOfFloat(array<float>)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -735,14 +725,12 @@ test("Supports Dict structs in union", t => {
     S.dict(S.float)->S.variant(v => #DictOfFloat(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #DictOf123(Js.Dict.t<string>)
-        | #DictOfFloat(Js.Dict.t<float>)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #DictOf123(Js.Dict.t<string>)
+      | #DictOfFloat(Js.Dict.t<float>)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -769,14 +757,12 @@ test("Supports Object structs in union", t => {
     )->S.variant(v => #Object2(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #Object({"field": string})
-        | #Object2({"field": float})
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #Object({"field": string})
+      | #Object2({"field": float})
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -794,20 +780,18 @@ test("Supports Object structs in union", t => {
 })
 
 test("Supports Tuple structs in union", t => {
-  let struct = S.union([S.tuple1(. S.literalVariant(String("123"), 123.)), S.tuple1(. S.float)])
+  let struct = S.union([S.tuple1(S.literalVariant(String("123"), 123.)), S.tuple1(S.float)])
   let structInlineResult = S.union([
-    S.tuple1(. S.literal(String("123")))->S.variant(v => #Tuple(v)),
-    S.tuple1(. S.float)->S.variant(v => #Tuple2(v)),
+    S.tuple1(S.literal(String("123")))->S.variant(v => #Tuple(v)),
+    S.tuple1(S.float)->S.variant(v => #Tuple2(v)),
   ])
 
-  structInlineResult->(
-    Obj.magic: S.t<
-      [
-        | #Tuple(string)
-        | #Tuple2(float)
-      ],
-    > => unit
-  )
+  let _: S.t<
+    [
+      | #Tuple(string)
+      | #Tuple2(float)
+    ],
+  > = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,
@@ -831,7 +815,7 @@ test("Supports Union structs in union", t => {
     ),
   ])
 
-  structInlineResult->(Obj.magic: S.t<[#Union([#red | #blue]) | #Union2([#0 | #1])]> => unit)
+  let _: S.t<[#Union([#red | #blue]) | #Union2([#0 | #1])]> = structInlineResult
 
   t->Assert.deepEqual(
     struct->S.inline,

--- a/__tests__/S_isAsyncParse_test.res
+++ b/__tests__/S_isAsyncParse_test.res
@@ -15,7 +15,7 @@ test("Returns true for async struct", t => {
 })
 
 test("Returns true for struct with nested async", t => {
-  let struct = S.tuple1(. S.string->S.refine(~asyncParser=_ => Promise.resolve(), ()))
+  let struct = S.tuple1(S.string->S.refine(~asyncParser=_ => Promise.resolve(), ()))
 
   t->Assert.is(struct->S.isAsyncParse, true, ())
 })

--- a/__tests__/S_object_discriminant_test.res
+++ b/__tests__/S_object_discriminant_test.res
@@ -50,7 +50,7 @@ module Positive = {
       (),
     ),
     TestData.make(
-      ~discriminantStruct=S.tuple2(. S.literal(Bool(false)), S.literal(String("bar"))),
+      ~discriminantStruct=S.tuple2(S.literal(Bool(false)), S.literal(String("bar"))),
       ~discriminantData=%raw(`[false, "bar"]`),
       (),
     ),
@@ -178,7 +178,7 @@ module Negative = {
       (),
     ),
     TestData.make(
-      ~discriminantStruct=S.tuple2(. S.literal(Bool(true)), S.bool),
+      ~discriminantStruct=S.tuple2(S.literal(Bool(true)), S.bool),
       ~discriminantData=(true, false),
       (),
     ),

--- a/__tests__/S_parseAnyAsyncInStepsWith_test.res
+++ b/__tests__/S_parseAnyAsyncInStepsWith_test.res
@@ -19,7 +19,7 @@ asyncTest("Successfully parses without asyncRefine", t => {
 
   (
     %raw(`"Hello world!"`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-  )(.)->Promise.thenResolve(result => {
+  )()->Promise.thenResolve(result => {
     t->Assert.deepEqual(result, Ok("Hello world!"), ())
   })
 })
@@ -43,7 +43,7 @@ asyncTest("Successfully parses with validAsyncRefine", t => {
 
   (
     %raw(`"Hello world!"`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-  )(.)->Promise.thenResolve(result => {
+  )()->Promise.thenResolve(result => {
     t->Assert.deepEqual(result, Ok("Hello world!"), ())
   })
 })
@@ -53,7 +53,7 @@ asyncTest("Fails to parse with invalidAsyncRefine", t => {
 
   (
     %raw(`"Hello world!"`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-  )(.)->Promise.thenResolve(result => {
+  )()->Promise.thenResolve(result => {
     t->Assert.deepEqual(
       result,
       Error({
@@ -84,7 +84,7 @@ module Object = {
       }
       ->S.parseAnyAsyncInStepsWith(struct)
       ->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Ok({
@@ -114,7 +114,7 @@ module Object = {
       }
       ->S.parseAnyAsyncInStepsWith(struct)
       ->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result->Belt.Result.map(Obj.magic)->Belt.Result.map(Js.Dict.keys),
         Ok(["k1", "k2", "k3"]),
@@ -142,7 +142,7 @@ module Object = {
       }
       ->S.parseAnyAsyncInStepsWith(struct)
       ->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Ok({
@@ -174,7 +174,7 @@ module Object = {
       }
       ->S.parseAnyAsyncInStepsWith(struct)
       ->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -304,7 +304,7 @@ module Object = {
       }
       ->S.parseAnyAsyncInStepsWith(struct)
       ->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -320,17 +320,17 @@ module Object = {
 
 module Tuple = {
   asyncTest("[Tuple] Successfully parses", t => {
-    let struct = S.tuple3(. S.int, S.int->validAsyncRefine, S.int)
+    let struct = S.tuple3(S.int, S.int->validAsyncRefine, S.int)
 
     (
       [1, 2, 3]->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(result, Ok(1, 2, 3), ())
     })
   })
 
   test("[Tuple] Returns sync error when fails to parse sync part of async item", t => {
-    let struct = S.tuple3(. S.int, S.int->validAsyncRefine, S.int)
+    let struct = S.tuple3(S.int, S.int->validAsyncRefine, S.int)
 
     t->Assert.deepEqual(
       %raw(`[1, true, 3]`)->S.parseAnyAsyncInStepsWith(struct),
@@ -344,7 +344,7 @@ module Tuple = {
   })
 
   test("[Tuple] Parses sync items first, and then starts parsing async ones", t => {
-    let struct = S.tuple3(.
+    let struct = S.tuple3(
       S.int,
       S.int->invalidSyncRefine->invalidAsyncRefine,
       S.int->invalidSyncRefine,
@@ -364,7 +364,7 @@ module Tuple = {
   test("[Tuple] Parses async items in parallel", t => {
     let actionCounter = ref(0)
 
-    let struct = S.tuple2(. S.int->S.advancedTransform(~parser=(~struct as _) => {
+    let struct = S.tuple2(S.int->S.advancedTransform(~parser=(~struct as _) => {
         Async(
           _ => {
             actionCounter.contents = actionCounter.contents + 1
@@ -386,13 +386,13 @@ module Tuple = {
   })
 
   asyncTest("[Tuple] Doesn't wait for pending async items when fails to parse", t => {
-    let struct = S.tuple2(. S.int->S.advancedTransform(~parser=(~struct as _) => {
+    let struct = S.tuple2(S.int->S.advancedTransform(~parser=(~struct as _) => {
         Async(_ => unresolvedPromise)
       }, ()), S.int->invalidAsyncRefine)
 
     (
       [1, 2]->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -415,19 +415,13 @@ module Union = {
     ])
 
     Promise.all([
-      (
-        1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(1), ())
       }),
-      (
-        2->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (2->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(2), ())
       }),
-      (
-        3->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (3->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(3), ())
       }),
     ])->Promise.thenResolve(_ => ())
@@ -442,7 +436,7 @@ module Union = {
 
     (
       true->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -502,7 +496,7 @@ module Array = {
 
     (
       [1, 2, 3]->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(result, Ok([1, 2, 3]), ())
     })
   })
@@ -556,7 +550,7 @@ module Array = {
 
     (
       [1, 2, 3]->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -576,7 +570,7 @@ module Dict = {
 
     (
       {"k1": 1, "k2": 2, "k3": 3}->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(result, Ok(Js.Dict.fromArray([("k1", 1), ("k2", 2), ("k3", 3)])), ())
     })
   })
@@ -630,7 +624,7 @@ module Dict = {
 
     (
       {"k1": 1, "k2": 2, "k3": 3}->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    )()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -649,14 +643,12 @@ module Null = {
     let struct = S.null(S.int->validAsyncRefine)
 
     Promise.all([
-      (
-        1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(Some(1)), ())
       }),
       (
         %raw(`null`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      )()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(None), ())
       }),
     ])->Promise.thenResolve(_ => ())
@@ -665,7 +657,7 @@ module Null = {
   asyncTest("[Null] Fails to parse with invalid async refine", t => {
     let struct = S.null(S.int->invalidAsyncRefine)
 
-    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)(.)->Promise.thenResolve(result => {
+    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -698,14 +690,12 @@ module Option = {
     let struct = S.option(S.int->validAsyncRefine)
 
     Promise.all([
-      (
-        1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(Some(1)), ())
       }),
       (
         %raw(`undefined`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      )()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(None), ())
       }),
     ])->Promise.thenResolve(_ => ())
@@ -714,7 +704,7 @@ module Option = {
   asyncTest("[Option] Fails to parse with invalid async refine", t => {
     let struct = S.option(S.int->invalidAsyncRefine)
 
-    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)(.)->Promise.thenResolve(result => {
+    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -747,14 +737,12 @@ module Defaulted = {
     let struct = S.int->validAsyncRefine->validAsyncRefine->S.default(() => 10)
 
     Promise.all([
-      (
-        1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(1), ())
       }),
       (
         %raw(`undefined`)->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-      )(.)->Promise.thenResolve(result => {
+      )()->Promise.thenResolve(result => {
         t->Assert.deepEqual(result, Ok(10), ())
       }),
     ])->Promise.thenResolve(_ => ())
@@ -763,7 +751,7 @@ module Defaulted = {
   asyncTest("[Default] Fails to parse with invalid async refine", t => {
     let struct = S.int->invalidAsyncRefine->S.default(() => 10)
 
-    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)(.)->Promise.thenResolve(result => {
+    (1->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({
@@ -796,9 +784,7 @@ module Json = {
   asyncTest("[JsonString] Successfully parses", t => {
     let struct = S.jsonString(S.int->validAsyncRefine)
 
-    (
-      "1"->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    ("1"->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
       t->Assert.deepEqual(result, Ok(1), ())
     })
   })
@@ -806,9 +792,7 @@ module Json = {
   asyncTest("[JsonString] Fails to parse with invalid async refine", t => {
     let struct = S.jsonString(S.int->invalidAsyncRefine)
 
-    (
-      "1"->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn
-    )(.)->Promise.thenResolve(result => {
+    ("1"->S.parseAnyAsyncInStepsWith(struct)->Belt.Result.getExn)()->Promise.thenResolve(result => {
       t->Assert.deepEqual(
         result,
         Error({

--- a/__tests__/S_serializeWith_test.res
+++ b/__tests__/S_serializeWith_test.res
@@ -25,7 +25,7 @@ test("Successfully serializes jsonable structs", t => {
     (),
   )
   t->Assert.deepEqual(
-    true->S.serializeWith(S.tuple1(. S.bool)),
+    true->S.serializeWith(S.tuple1(S.bool)),
     Json.array([Json.boolean(true)])->Ok,
     (),
   )
@@ -110,7 +110,7 @@ test("Fails to serialize object with invalid nested struct", t => {
 
 test("Fails to serialize tuple with invalid nested struct", t => {
   t->Assert.deepEqual(
-    Obj.magic(true)->S.serializeWith(S.tuple1(. S.unknown)),
+    Obj.magic(true)->S.serializeWith(S.tuple1(S.unknown)),
     Error({
       code: InvalidJsonStruct({received: "Unknown"}),
       operation: Serializing,
@@ -122,9 +122,7 @@ test("Fails to serialize tuple with invalid nested struct", t => {
 
 test("Fails to serialize union if one of the items is an invalid struct", t => {
   t->Assert.deepEqual(
-    "foo"->S.serializeWith(
-      S.union([S.string, S.unknown->(Obj.magic: S.t<unknown> => S.t<string>)]),
-    ),
+    "foo"->S.serializeWith(S.union([S.string, (S.unknown: S.t<unknown>)->Obj.magic])),
     Error({
       code: InvalidJsonStruct({received: "Unknown"}),
       operation: Serializing,

--- a/__tests__/S_tuple0_test.res
+++ b/__tests__/S_tuple0_test.res
@@ -5,7 +5,7 @@ module Common = {
   let any = %raw(`[]`)
   let wrongAny = %raw(`[true]`)
   let wrongTypeAny = %raw(`"Hello world!"`)
-  let factory = () => S.tuple0(.)
+  let factory = () => S.tuple0()
 
   test("Successfully parses", t => {
     let struct = factory()

--- a/__tests__/S_tuple1_test.res
+++ b/__tests__/S_tuple1_test.res
@@ -5,7 +5,7 @@ module Common = {
   let any = %raw(`[123]`)
   let wrongAny = %raw(`[123, true]`)
   let wrongTypeAny = %raw(`"Hello world!"`)
-  let factory = () => S.tuple1(. S.int)
+  let factory = () => S.tuple1(S.int)
 
   test("Successfully parses", t => {
     let struct = factory()

--- a/__tests__/S_tuple2_test.res
+++ b/__tests__/S_tuple2_test.res
@@ -5,7 +5,7 @@ module Common = {
   let any = %raw(`[123, true]`)
   let wrongAny = %raw(`[123]`)
   let wrongTypeAny = %raw(`"Hello world!"`)
-  let factory = () => S.tuple2(. S.int, S.bool)
+  let factory = () => S.tuple2(S.int, S.bool)
 
   test("Successfully parses", t => {
     let struct = factory()

--- a/__tests__/S_variant_test.res
+++ b/__tests__/S_variant_test.res
@@ -53,7 +53,7 @@ test("Fails to serialize when the value is not used as the variant payload", t =
 test(
   "Successfully serializes when the value is not used as the variant payload for literal structs",
   t => {
-    let struct = S.tuple2(. S.literal(Bool(true)), S.literal(Int(12)))->S.variant(_ => #foo)
+    let struct = S.tuple2(S.literal(Bool(true)), S.literal(Int(12)))->S.variant(_ => #foo)
 
     t->Assert.deepEqual(#foo->S.serializeToUnknownWith(struct), Ok(%raw(`[true, 12]`)), ())
   },

--- a/benchmark/Benchmark.res
+++ b/benchmark/Benchmark.res
@@ -13,10 +13,10 @@ module Suite = {
   external make: unit => t = "Suite"
 
   @send
-  external add: (t, string, (. unit) => 'a) => t = "add"
+  external add: (t, string, unit => 'a) => t = "add"
 
   let addWithPrepare = (suite, name, fn) => {
-    suite->add(name, fn(.))
+    suite->add(name, fn())
   }
 
   @send
@@ -34,7 +34,7 @@ module Suite = {
   }
 }
 
-let makeTestObject = (. ()) => {
+let makeTestObject = () => {
   %raw(`Object.freeze({
     number: 1,
     negNumber: -1,
@@ -51,7 +51,7 @@ let makeTestObject = (. ()) => {
   })`)
 }
 
-let makeAdvancedObjectStruct = (. ()) => {
+let makeAdvancedObjectStruct = () => {
   S.object(o =>
     {
       "number": o.field("number", S.float),
@@ -74,7 +74,7 @@ let makeAdvancedObjectStruct = (. ()) => {
   )
 }
 
-let makeAdvancedStrictObjectStruct = (. ()) => {
+let makeAdvancedStrictObjectStruct = () => {
   S.object(o =>
     {
       "number": o.field("number", S.float),
@@ -98,46 +98,46 @@ let makeAdvancedStrictObjectStruct = (. ()) => {
 }
 
 Suite.make()
-->Suite.addWithPrepare("Parse string", (. ()) => {
+->Suite.addWithPrepare("Parse string", () => {
   let struct = S.string
   let data = "Hello world!"
-  (. ()) => {
+  () => {
     data->S.parseAnyOrRaiseWith(struct)
   }
 })
-->Suite.addWithPrepare("Serialize string", (. ()) => {
+->Suite.addWithPrepare("Serialize string", () => {
   let struct = S.string
   let data = "Hello world!"
-  (. ()) => {
+  () => {
     data->S.serializeOrRaiseWith(struct)
   }
 })
 ->Suite.add("Advanced object struct factory", makeAdvancedObjectStruct)
-->Suite.addWithPrepare("Parse advanced object", (. ()) => {
+->Suite.addWithPrepare("Parse advanced object", () => {
   let struct = makeAdvancedObjectStruct()
   let data = makeTestObject()
-  (. ()) => {
+  () => {
     data->S.parseAnyOrRaiseWith(struct)
   }
 })
-->Suite.addWithPrepare("Create and parse advanced object", (. ()) => {
+->Suite.addWithPrepare("Create and parse advanced object", () => {
   let data = makeTestObject()
-  (. ()) => {
+  () => {
     let struct = makeAdvancedObjectStruct()
     data->S.parseAnyOrRaiseWith(struct)
   }
 })
-->Suite.addWithPrepare("Parse advanced strict object", (. ()) => {
+->Suite.addWithPrepare("Parse advanced strict object", () => {
   let struct = makeAdvancedStrictObjectStruct()
   let data = makeTestObject()
-  (. ()) => {
+  () => {
     data->S.parseAnyOrRaiseWith(struct)
   }
 })
-->Suite.addWithPrepare("Serialize advanced object", (. ()) => {
+->Suite.addWithPrepare("Serialize advanced object", () => {
   let struct = makeAdvancedObjectStruct()
   let data = makeTestObject()
-  (. ()) => {
+  () => {
     data->S.serializeOrRaiseWith(struct)
   }
 })

--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
     "ava": "5.2.0",
     "benchmark": "2.1.4",
     "c8": "7.12.0",
-    "rescript": "11.0.0-alpha.6",
+    "rescript": "11.0.0-beta.2",
+    "rescript-struct": ".",
     "ts-expect": "1.3.0",
     "ts-node": "10.9.1",
-    "typescript": "4.9.3",
-    "rescript-struct": "."
+    "typescript": "4.9.3"
   },
   "peerDependencies": {
-    "rescript": "10.1.x || ~11.0.0-alpha"
+    "rescript": "10.1.x || ~11.0.0-alpha || ~11.0.0-beta"
   },
   "packageManager": "pnpm@8.3.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ importers:
     devDependencies:
       '@dzakh/rescript-ava':
         specifier: 2.3.0
-        version: 2.3.0(ava@5.2.0)(rescript@11.0.0-alpha.6)
+        version: 2.3.0(ava@5.2.0)(rescript@11.0.0-beta.2)
       '@ryyppy/rescript-promise':
         specifier: 2.1.0
         version: 2.1.0
@@ -20,8 +20,8 @@ importers:
         specifier: 7.12.0
         version: 7.12.0
       rescript:
-        specifier: 11.0.0-alpha.6
-        version: 11.0.0-alpha.6
+        specifier: 11.0.0-beta.2
+        version: 11.0.0-beta.2
       rescript-struct:
         specifier: .
         version: 'link:'
@@ -98,6 +98,17 @@ packages:
     dependencies:
       ava: 5.2.0
       rescript: 11.0.0-alpha.6
+    dev: false
+
+  /@dzakh/rescript-ava@2.3.0(ava@5.2.0)(rescript@11.0.0-beta.2):
+    resolution: {integrity: sha512-str7Fh+lYxWNf+wDAHykw84bqKodrwU5swLcYNjc8BJc3N4ECyNBA3o5vFNsq0zZw+1eExARs8mUnB2ZQSmRGg==}
+    peerDependencies:
+      ava: 5.2.x
+      rescript: 10.1.x || ~11.0.0-alpha
+    dependencies:
+      ava: 5.2.0
+      rescript: 11.0.0-beta.2
+    dev: true
 
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
@@ -1125,6 +1136,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     requiresBuild: true
+    dev: false
+
+  /rescript@11.0.0-beta.2:
+    resolution: {integrity: sha512-Tcf72sR4EQ+eVMAwMWDSW5VPfg8YOS6bRJQ1Sf4u6jMy7Ui18mZyy0rusQmeq8vf2spgNulMcOw+HzQ9bEiz7g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    requiresBuild: true
+    dev: true
 
   /resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}

--- a/src/S.resi
+++ b/src/S.resi
@@ -169,12 +169,12 @@ let parseAnyAsyncWith: ('any, t<'value>) => promise<result<'value, Error.t>>
 let parseAsyncInStepsWith: (
   Js.Json.t,
   t<'value>,
-) => result<(. unit) => promise<result<'value, Error.t>>, Error.t>
+) => result<unit => promise<result<'value, Error.t>>, Error.t>
 
 let parseAnyAsyncInStepsWith: (
   'any,
   t<'value>,
-) => result<(. unit) => promise<result<'value, Error.t>>, Error.t>
+) => result<unit => promise<result<'value, Error.t>>, Error.t>
 
 let serializeWith: ('value, t<'value>) => result<Js.Json.t, Error.t>
 
@@ -202,7 +202,7 @@ let fail: (~path: Path.t=?, string) => 'a
 let advancedFail: Error.t => 'a
 
 module Object: {
-  type ctx = {@as("f") field: 'value. (. string, t<'value>) => 'value}
+  type ctx = {@as("f") field: 'value. (string, t<'value>) => 'value}
 
   module UnknownKeys: {
     type tagged = Strict | Strip
@@ -223,15 +223,15 @@ module Tuple: {
   let factory: array<t<unknown>> => t<array<unknown>>
 }
 
-let tuple0: (. unit) => t<unit>
-let tuple1: (. t<'value>) => t<'value>
-let tuple2: (. t<'v1>, t<'v2>) => t<('v1, 'v2)>
-let tuple3: (. t<'v1>, t<'v2>, t<'v3>) => t<('v1, 'v2, 'v3)>
-let tuple4: (. t<'v1>, t<'v2>, t<'v3>, t<'v4>) => t<('v1, 'v2, 'v3, 'v4)>
-let tuple5: (. t<'v1>, t<'v2>, t<'v3>, t<'v4>, t<'v5>) => t<('v1, 'v2, 'v3, 'v4, 'v5)>
-let tuple6: (. t<'v1>, t<'v2>, t<'v3>, t<'v4>, t<'v5>, t<'v6>) => t<('v1, 'v2, 'v3, 'v4, 'v5, 'v6)>
+let tuple0: unit => t<unit>
+let tuple1: t<'value> => t<'value>
+let tuple2: (t<'v1>, t<'v2>) => t<('v1, 'v2)>
+let tuple3: (t<'v1>, t<'v2>, t<'v3>) => t<('v1, 'v2, 'v3)>
+let tuple4: (t<'v1>, t<'v2>, t<'v3>, t<'v4>) => t<('v1, 'v2, 'v3, 'v4)>
+let tuple5: (t<'v1>, t<'v2>, t<'v3>, t<'v4>, t<'v5>) => t<('v1, 'v2, 'v3, 'v4, 'v5)>
+let tuple6: (t<'v1>, t<'v2>, t<'v3>, t<'v4>, t<'v5>, t<'v6>) => t<('v1, 'v2, 'v3, 'v4, 'v5, 'v6)>
 let tuple7: (
-  . t<'v1>,
+  t<'v1>,
   t<'v2>,
   t<'v3>,
   t<'v4>,
@@ -240,7 +240,7 @@ let tuple7: (
   t<'v7>,
 ) => t<('v1, 'v2, 'v3, 'v4, 'v5, 'v6, 'v7)>
 let tuple8: (
-  . t<'v1>,
+  t<'v1>,
   t<'v2>,
   t<'v3>,
   t<'v4>,
@@ -250,7 +250,7 @@ let tuple8: (
   t<'v8>,
 ) => t<('v1, 'v2, 'v3, 'v4, 'v5, 'v6, 'v7, 'v8)>
 let tuple9: (
-  . t<'v1>,
+  t<'v1>,
   t<'v2>,
   t<'v3>,
   t<'v4>,
@@ -261,7 +261,7 @@ let tuple9: (
   t<'v9>,
 ) => t<('v1, 'v2, 'v3, 'v4, 'v5, 'v6, 'v7, 'v8, 'v9)>
 let tuple10: (
-  . t<'v1>,
+  t<'v1>,
   t<'v2>,
   t<'v3>,
   t<'v4>,

--- a/src/S_JsApi.bs.mjs
+++ b/src/S_JsApi.bs.mjs
@@ -12,6 +12,10 @@ export class RescriptStructError extends Error {
     }
 ;
 
+function make(error) {
+  return new RescriptStructError(S$RescriptStruct.$$Error.toString(error));
+}
+
 function fromOk(value) {
   return {
           success: true,
@@ -40,7 +44,7 @@ function parse(data) {
   catch (raw_error){
     var error = Caml_js_exceptions.internalToOCamlException(raw_error);
     if (error.RE_EXN_ID === S$RescriptStruct.Raised) {
-      return fromError(new RescriptStructError(S$RescriptStruct.$$Error.toString(error._1)));
+      return fromError(make(error._1));
     }
     throw error;
   }
@@ -54,7 +58,7 @@ function parseOrThrow(data) {
   catch (raw_error){
     var error = Caml_js_exceptions.internalToOCamlException(raw_error);
     if (error.RE_EXN_ID === S$RescriptStruct.Raised) {
-      throw new RescriptStructError(S$RescriptStruct.$$Error.toString(error._1));
+      throw make(error._1);
     }
     throw error;
   }
@@ -66,7 +70,7 @@ function parseAsync(data) {
               if (result.TAG === "Ok") {
                 return fromOk(result._0);
               } else {
-                return fromError(new RescriptStructError(S$RescriptStruct.$$Error.toString(result._0)));
+                return fromError(make(result._0));
               }
             });
 }
@@ -79,7 +83,7 @@ function serialize(value) {
   catch (raw_error){
     var error = Caml_js_exceptions.internalToOCamlException(raw_error);
     if (error.RE_EXN_ID === S$RescriptStruct.Raised) {
-      return fromError(new RescriptStructError(S$RescriptStruct.$$Error.toString(error._1)));
+      return fromError(make(error._1));
     }
     throw error;
   }
@@ -93,7 +97,7 @@ function serializeOrThrow(value) {
   catch (raw_error){
     var error = Caml_js_exceptions.internalToOCamlException(raw_error);
     if (error.RE_EXN_ID === S$RescriptStruct.Raised) {
-      throw new RescriptStructError(S$RescriptStruct.$$Error.toString(error._1));
+      throw make(error._1);
     }
     throw error;
   }
@@ -123,8 +127,9 @@ function describe(description) {
   return Object.assign(struct$1, structOperations);
 }
 
-function description(param) {
-  return S$RescriptStruct.description(this);
+function description() {
+  var struct = this;
+  return S$RescriptStruct.description(struct);
 }
 
 function $$default(def) {
@@ -207,10 +212,10 @@ Object.assign(structOperations, {
       transform: transform,
       refine: refine,
       asyncRefine: asyncRefine,
-      optional: (function (param) {
+      optional: (function () {
           return optional(this);
         }),
-      nullable: (function (param) {
+      nullable: (function () {
           return nullable(this);
         }),
       describe: describe,
@@ -238,12 +243,12 @@ var nan = Object.assign(struct, structOperations);
 
 var objectStructOperations = {};
 
-function strict(param) {
+function strict() {
   var struct = this;
   return Object.assign(S$RescriptStruct.$$Object.strict(struct), objectStructOperations);
 }
 
-function strip(param) {
+function strip() {
   var struct = this;
   return Object.assign(S$RescriptStruct.$$Object.strip(struct), objectStructOperations);
 }


### PR DESCRIPTION
Nothing major here - I was just fiddling around because I was experimenting with the latest v11 candidate on another repo. I thought there was an issue with rescript-struct from the error messages I got, but turns out I was just being silly. :grimacing: 

Anyway, I thought this update would maybe be appreciated.

Summary:
1. Upgraded to the latest beta.
2. Fix issues that arose in the code (uncurried by default struggled with the type annotations for `Obj.magic` for some reason)
3. Ran `pnpm rescript format -all`

In hindsight I think keeping the bsconfig to have `"uncurried": false` probably makes sense to make sure nothing breaks. Making another PR with that too